### PR TITLE
Add memory cleanup in model destructors

### DIFF
--- a/server/voice_changer/Beatrice/Beatrice.py
+++ b/server/voice_changer/Beatrice/Beatrice.py
@@ -1,4 +1,6 @@
 from data.ModelSlot import BeatriceModelSlot
+import gc
+import torch
 from mods.log_control import VoiceChangaerLogger
 
 from voice_changer.utils.VoiceChangerModel import AudioInOut, VoiceChangerModel
@@ -39,7 +41,15 @@ class Beatrice(VoiceChangerModel):
         raise RuntimeError("not implemented")
 
     def __del__(self):
-        del self.pipeline
+        if hasattr(self, "pipeline"):
+            del self.pipeline
+            self.pipeline = None
+
+        if getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
+            torch.mps.empty_cache()
+        elif torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        gc.collect()
 
     def get_model_current(self):
         return [

--- a/server/voice_changer/EasyVC/EasyVC.py
+++ b/server/voice_changer/EasyVC/EasyVC.py
@@ -3,6 +3,7 @@ VoiceChangerV2向け
 """
 
 from dataclasses import asdict
+import gc
 import numpy as np
 import torch
 from data.ModelSlot import RVCModelSlot
@@ -269,7 +270,15 @@ class EasyVC(VoiceChangerModel):
         return
 
     def __del__(self):
-        del self.pipeline
+        if hasattr(self, "pipeline"):
+            del self.pipeline
+            self.pipeline = None
+
+        if getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
+            torch.mps.empty_cache()
+        elif torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        gc.collect()
 
         # print("---------- REMOVING ---------------")
 

--- a/server/voice_changer/RVC/RVCr2.py
+++ b/server/voice_changer/RVC/RVCr2.py
@@ -3,6 +3,7 @@ VoiceChangerV2向け
 """
 
 from dataclasses import asdict
+import gc
 import numpy as np
 import torch
 from data.ModelSlot import RVCModelSlot
@@ -264,7 +265,15 @@ class RVCr2(VoiceChangerModel):
         return
 
     def __del__(self):
-        del self.pipeline
+        if hasattr(self, "pipeline"):
+            del self.pipeline
+            self.pipeline = None
+
+        if getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
+            torch.mps.empty_cache()
+        elif torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        gc.collect()
 
         # print("---------- REMOVING ---------------")
 


### PR DESCRIPTION
## Summary
- update destructors for GPU cache cleanup across voice changer models
- import `gc` where needed

## Testing
- `black --line-length 550 server/voice_changer/RVC/RVC.py server/voice_changer/RVC/RVCr2.py server/voice_changer/EasyVC/EasyVC.py server/voice_changer/MMVCv15/MMVCv15.py server/voice_changer/MMVCv13/MMVCv13.py server/voice_changer/SoVitsSvc40/SoVitsSvc40.py server/voice_changer/DiffusionSVC/DiffusionSVC.py server/voice_changer/Beatrice/Beatrice.py`
- `flake8 --max-line-length=1024 --ignore=E402,E203,E722 server/voice_changer/RVC/RVC.py server/voice_changer/RVC/RVCr2.py server/voice_changer/EasyVC/EasyVC.py server/voice_changer/MMVCv15/MMVCv15.py server/voice_changer/MMVCv13/MMVCv13.py server/voice_changer/SoVitsSvc40/SoVitsSvc40.py server/voice_changer/DiffusionSVC/DiffusionSVC.py server/voice_changer/Beatrice/Beatrice.py` *(fails: `flake8: command not found`)*
- `python -m py_compile server/voice_changer/RVC/RVC.py server/voice_changer/RVC/RVCr2.py server/voice_changer/EasyVC/EasyVC.py server/voice_changer/MMVCv15/MMVCv15.py server/voice_changer/MMVCv13/MMVCv13.py server/voice_changer/SoVitsSvc40/SoVitsSvc40.py server/voice_changer/DiffusionSVC/DiffusionSVC.py server/voice_changer/Beatrice/Beatrice.py`